### PR TITLE
Fix TestMenu issues

### DIFF
--- a/examples/TestMenu/TestMenu.h
+++ b/examples/TestMenu/TestMenu.h
@@ -1,24 +1,24 @@
-// required for "prog_char" and "PROGMEM"
+// required for "const char" and "PROGMEM"
 #include <avr/pgmspace.h>
 
 // texts for menus
 
-prog_char itmBack[] PROGMEM = "< Back";
-prog_char itmOn[] PROGMEM = "On";
-prog_char itmOff[] PROGMEM = "Off";
-prog_char itmEnabled[] PROGMEM = "Enabled";
-prog_char itmDisabled[] PROGMEM = "Disabled";
+const char itmBack[] PROGMEM = "< Back";
+const char itmOn[] PROGMEM = "On";
+const char itmOff[] PROGMEM = "Off";
+const char itmEnabled[] PROGMEM = "Enabled";
+const char itmDisabled[] PROGMEM = "Disabled";
 
-prog_char itmRoot[] PROGMEM = "Root menu";
-prog_char itmSubmenu1[] PROGMEM = "Submenu 1";
-prog_char itmSubmenu2[] PROGMEM = "Submenu 2";
-prog_char itmSubmenu3[] PROGMEM = "Submenu 3";
-prog_char itmMessageBox[] PROGMEM = "Message box";
-prog_char itmItem1[] PROGMEM = "Item 1";
-prog_char itmItem2[] PROGMEM = "Item 2";
-prog_char itmItem3[] PROGMEM = "Item 3";
-prog_char itmItem4[] PROGMEM = "Item 4";
-prog_char itmItem5[] PROGMEM = "Item 5";
+const char itmRoot[] PROGMEM = "Root menu";
+const char itmSubmenu1[] PROGMEM = "Submenu 1";
+const char itmSubmenu2[] PROGMEM = "Submenu 2";
+const char itmSubmenu3[] PROGMEM = "Submenu 3";
+const char itmMessageBox[] PROGMEM = "Message box";
+const char itmItem1[] PROGMEM = "Item 1";
+const char itmItem2[] PROGMEM = "Item 2";
+const char itmItem3[] PROGMEM = "Item 3";
+const char itmItem4[] PROGMEM = "Item 4";
+const char itmItem5[] PROGMEM = "Item 5";
 
 ////////////////////////////////////////////////////////////////
 // menus - first item is menu title and it does not count toward cnt

--- a/examples/TestMenu/TestMenu.h
+++ b/examples/TestMenu/TestMenu.h
@@ -23,25 +23,25 @@ const char itmItem5[] PROGMEM = "Item 5";
 ////////////////////////////////////////////////////////////////
 // menus - first item is menu title and it does not count toward cnt
 
-PROGMEM const char * mnuRoot[] = {
+const char * mnuRoot[] PROGMEM = {
   itmRoot,
   itmSubmenu1,itmSubmenu2,itmSubmenu3,itmMessageBox};
-PROGMEM const int cntRoot = 4;
+const int cntRoot PROGMEM = 4;
 
-PROGMEM const char * mnuSubmenu1[] = {
+const char * mnuSubmenu1[] PROGMEM = {
   itmSubmenu1,
   itmItem1,itmItem2,itmItem3,itmItem4,itmItem5,itmBack};
-PROGMEM const int cntSubmenu1 = 6;
+const int cntSubmenu1 PROGMEM = 6;
 
-PROGMEM const char * mnuSubmenu2[] = {
+const char * mnuSubmenu2[] PROGMEM = {
   itmSubmenu2,
   itmOn,itmOff,itmBack};
-PROGMEM const int cntSubmenu2 = 3;
+const int cntSubmenu2 PROGMEM = 3;
 
-PROGMEM const char * mnuSubmenu3[] = {
+const char * mnuSubmenu3[] PROGMEM = {
   itmSubmenu3,
   itmEnabled,itmDisabled,itmBack};
-PROGMEM const int cntSubmenu3 = 3;
+const int cntSubmenu3 PROGMEM = 3;
 
 
 


### PR DESCRIPTION
Remove deprecated `prog_char` type.
(See [here](https://www.nongnu.org/avr-libc/user-manual/group__avr__pgmspace.html#gaa475b6b81fd8b34de45695da1da523b6) for details.)

Use recommended placement for `PROGMEM` macro.
(See [here](https://www.arduino.cc/reference/en/language/variables/utilities/progmem/) for details.)
